### PR TITLE
bug fixing for issue 53

### DIFF
--- a/extractor/update_type_conference.py
+++ b/extractor/update_type_conference.py
@@ -25,10 +25,10 @@ def update_type_conference(cnx, dblp_key):
 	
     cursor = cnx.cursor()
     type = ''
-    if 'conference' in title.lower():
-        type = 'conference'
-    elif 'workshop' in title.lower():
+    if 'workshop' in title.lower():
         type = 'workshop'
+    elif 'conference' in title.lower():
+        type = 'conference'
     elif 'symposium' in title.lower():
         type = 'symposium'
 


### PR DESCRIPTION
The if-else cascade has been modified to check first if a title of proceedings contains the word "workshop" and then the word "conference".

For instance, the problem for VLDB was due to the fact that the workshop proceedings in 2003 had the following title: 
`Proceedings of the VLDB 2003 PhD Workshop. Co-located with the 29th International Conference on Very Large Data Bases (VLDB 2003). Berlin, September 12-13, 2003`. 
Thus such a title was recognized as belonging to a conference, instead of a workshop.

This pull request fix #53
